### PR TITLE
Fix Decap CMS init timing

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <title>CMS | PrecisionPCs</title>
 
-    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-    <script src="https://unpkg.com/decap-cms@3.6.3/dist/decap-cms.js"></script>
+    <script src="https://identity.netlify.com/v1/netlify-identity-widget.js" defer></script>
+    <script src="https://unpkg.com/decap-cms@3.6.3/dist/decap-cms.js" defer></script>
 
     <link rel="stylesheet" href="admin/css/material.css" />
     <link rel="stylesheet" href="admin/css/codemirror.css" />


### PR DESCRIPTION
## Summary
- ensure Decap CMS scripts load after the DOM is ready by deferring them

## Testing
- `npm run build`
- `npm run cms:build`


------
https://chatgpt.com/codex/tasks/task_e_684ccfe85ad483289d3c6f585725b5a1