### PR TITLE
Fix homepage image ratio

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,7 +60,7 @@ const posts = await getCollection('blog');
       }
       .card img {
         width: 100%;
-        height: 200px;
+        aspect-ratio: 16 / 9;
         object-fit: cover;
       }
       .card-content {


### PR DESCRIPTION
## Summary
- keep blog thumbnail images from stretching by using an aspect ratio

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853070d5e0c8328973700ceeb96f7ba