### PR TITLE
Fix homepage image ratio

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,8 +60,8 @@ const posts = await getCollection('blog');
       }
       .card img {
         width: 100%;
-        height: 200px;
-        object-fit: cover;
+        height: auto;
+        display: block;
       }
       .card-content {
         padding: 1rem;
@@ -114,7 +114,9 @@ const posts = await getCollection('blog');
       const tags = new Set();
       posts.forEach(card => {
         const postTags = JSON.parse(card.dataset.tags || '[]');
-        postTags.forEach(tag => tags.add(tag));
+        postTags.forEach(tag => {
+          if (tag && tag.trim()) tags.add(tag);
+        });
       });
 
       tags.forEach(tag => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,9 +59,11 @@ const posts = await getCollection('blog');
         transform: scale(1.02);
       }
       .card img {
-        width: 100%;
+        max-width: 100%;
         height: auto;
+        max-height: 250px;
         display: block;
+        margin: 0 auto;
       }
       .card-content {
         padding: 1rem;
@@ -115,7 +117,8 @@ const posts = await getCollection('blog');
       posts.forEach(card => {
         const postTags = JSON.parse(card.dataset.tags || '[]');
         postTags.forEach(tag => {
-          if (tag && tag.trim()) tags.add(tag);
+          const cleaned = tag && tag.trim();
+          if (cleaned) tags.add(cleaned);
         });
       });
 


### PR DESCRIPTION
## Summary
- adjust card images so they use their natural aspect ratio
- ignore blank tags when generating tag filter

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853070d5e0c8328973700ceeb96f7ba