### PR TITLE
Fix snippet ordering

### DIFF
--- a/public/admin/index.html
+++ b/public/admin/index.html
@@ -1,6 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?('&l='+l):'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N5MFBWR6');</script>
+    <!-- End Google Tag Manager -->
+    <script type="text/javascript">
+      var _iub = _iub || [];
+      _iub.csConfiguration = {"siteId":4077795,"cookiePolicyId":33175883,"lang":"en","storage":{"useSiteId":true}};
+    </script>
+    <script type="text/javascript" src="https://cs.iubenda.com/autoblocking/4077795.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/gpp/stub.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <meta charset="UTF-8" />
     <title>CMS | PrecisionPCs</title>
 
@@ -14,6 +28,9 @@
     <link rel="stylesheet" href="admin/css/ol.css" />
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N5MFBWR6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="nc-root"></div>
     <script type="module" src="/admin/index.js"></script>
   </body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -3,7 +3,21 @@
 
 <html lang="en">
   <head>
-  <link rel="icon" type="image/png" href="/uploads/logo.png">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?('&l='+l):'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N5MFBWR6');</script>
+    <!-- End Google Tag Manager -->
+    <script type="text/javascript">
+      var _iub = _iub || [];
+      _iub.csConfiguration = {"siteId":4077795,"cookiePolicyId":33175883,"lang":"en","storage":{"useSiteId":true}};
+    </script>
+    <script type="text/javascript" src="https://cs.iubenda.com/autoblocking/4077795.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/gpp/stub.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
+    <link rel="icon" type="image/png" href="/uploads/logo.png">
     <meta charset="UTF-8">
     <title>Page Not Found</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -26,6 +40,9 @@
     </style>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N5MFBWR6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <header>
       <a href="/"><img src="/uploads/logo.png" alt="Logo" style="max-width:160px"></a>
     </header>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -12,6 +12,20 @@ if (!post) throw new Error(`Post not found: ${slug}`);
 ---
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?('&l='+l):'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N5MFBWR6');</script>
+    <!-- End Google Tag Manager -->
+    <script type="text/javascript">
+      var _iub = _iub || [];
+      _iub.csConfiguration = {"siteId":4077795,"cookiePolicyId":33175883,"lang":"en","storage":{"useSiteId":true}};
+    </script>
+    <script type="text/javascript" src="https://cs.iubenda.com/autoblocking/4077795.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/gpp/stub.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
     <link rel="icon" type="image/png" href="/uploads/logo.png">
     <meta charset="UTF-8">
     <title>{post.data.title}</title>
@@ -34,6 +48,9 @@ if (!post) throw new Error(`Post not found: ${slug}`);
     </style>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N5MFBWR6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <header>
       <a href="/"><img src="/uploads/logo.png" alt="Logo" style="max-width:160px"></a>
     </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,21 @@ const posts = await getCollection('blog');
 
 <html lang="en">
   <head>
-  <link rel="icon" type="image/png" href="/uploads/logo.png">
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?('&l='+l):'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N5MFBWR6');</script>
+    <!-- End Google Tag Manager -->
+    <script type="text/javascript">
+      var _iub = _iub || [];
+      _iub.csConfiguration = {"siteId":4077795,"cookiePolicyId":33175883,"lang":"en","storage":{"useSiteId":true}};
+    </script>
+    <script type="text/javascript" src="https://cs.iubenda.com/autoblocking/4077795.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/gpp/stub.js"></script>
+    <script type="text/javascript" src="https://cdn.iubenda.com/cs/iubenda_cs.js" charset="UTF-8" async></script>
+    <link rel="icon" type="image/png" href="/uploads/logo.png">
     <meta charset="UTF-8">
     <title>Precision PCs Blog</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -81,6 +95,9 @@ const posts = await getCollection('blog');
     </style>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N5MFBWR6" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <header>
   <nav style="display: flex; justify-content: space-between; align-items: center; background: white; padding: 1rem 2rem; box-shadow: 0 2px 6px rgba(0,0,0,0.1);">
     <div style="display: flex; align-items: center;">


### PR DESCRIPTION
## Summary
- place Google Analytics snippet before cookie consent scripts
- update consent snippet to match latest requirement
- include Google AdSense meta tag
- switch to Google Tag Manager on every page
- inject GTM noscript snippet at the start of each page body
- remove Google AdSense meta

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68530b11f3b08328970404f4faaa5c44